### PR TITLE
Add Integer DDL compiler

### DIFF
--- a/pyathena/alembic.py
+++ b/pyathena/alembic.py
@@ -4,6 +4,9 @@ from alembic.ddl.base import AddColumn
 from alembic.ddl.base import alter_table
 from sqlalchemy.ext.compiler import compiles
 
+from sqlalchemy.sql.sqltypes import INTEGER, Integer
+from sqlalchemy.schema import CreateColumn
+
 
 _DIALECT_NAME = 'awsathena'
 
@@ -22,6 +25,12 @@ def visit_add_column(element, compiler, **kw):
 
 def add_columns(compiler, column, **kw):
     return "ADD COLUMNS (%s)" % compiler.get_column_specification(column, **kw)
+
+
+@compiles(Integer, _DIALECT_NAME)
+@compiles(INTEGER, _DIALECT_NAME)
+def visit_INTEGER(element, ddlcompiler, **kw):
+    return 'int'
 
 
 # vim: et:sw=4:syntax=python:ts=4:


### PR DESCRIPTION
Athena uses different expressions for integer depending on the type of query.

int – In Data Definition Language (DDL) queries like CREATE TABLE, use the int data type.
integer – In DML queries like SELECT * FROM, use the integer data type.